### PR TITLE
feat: Production-Ready Permission Management Page for Commdesk Admin 

### DIFF
--- a/src/features/Permissions/v1/Components/MemberPermissionCard.tsx
+++ b/src/features/Permissions/v1/Components/MemberPermissionCard.tsx
@@ -1,0 +1,85 @@
+import RoleChip from "@/features/Member/v1/Components/RoleChip";
+import PermissionChip from "./PermissionChip";
+import { PermissionMember } from "../mock/permissionData";
+
+const MemberPermissionCard = ({ member }: { member: PermissionMember }) => {
+  return (
+    <div
+      className="w-full flex flex-col gap-4 p-5 rounded-2xl border"
+      style={{
+        backgroundColor: "var(--cd-surface)",
+        borderColor: "var(--cd-border)",
+      }}
+    >
+      {/* Top — avatar, name, role, email */}
+      <div className="flex items-center gap-4">
+        <img
+          src={member.image}
+          alt={member.name}
+          className="w-14 h-14 rounded-full object-cover"
+        />
+        <div className="flex flex-col gap-1">
+          <h3
+            className="text-sm font-bold"
+            style={{ color: "var(--cd-text)" }}
+          >
+            {member.name}
+          </h3>
+          <p
+            className="text-xs"
+            style={{ color: "var(--cd-text-2)" }}
+          >
+            {member.email}
+          </p>
+          <RoleChip role={member.role} />
+        </div>
+
+        {/* Status badge — top right */}
+        <div className="ml-auto">
+          <span
+            className="text-xs px-3 py-1 rounded-full font-medium"
+            style={{
+              backgroundColor:
+                member.status === "Active"
+                  ? "var(--cd-success-subtle)"
+                  : "var(--cd-surface-2)",
+              color:
+                member.status === "Active"
+                  ? "var(--cd-success)"
+                  : "var(--cd-text-muted)",
+            }}
+          >
+            {member.status}
+          </span>
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div
+        className="w-full h-px"
+        style={{ backgroundColor: "var(--cd-border)" }}
+      />
+
+      {/* Permissions */}
+      <div className="flex flex-col gap-2">
+        <p
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--cd-text-muted)" }}
+        >
+          Permissions
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {member.permissions.map((perm) => (
+            <PermissionChip
+              key={perm.label}
+              label={perm.label}
+              granted={perm.granted}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MemberPermissionCard;

--- a/src/features/Permissions/v1/Components/MemberPermissionCard.tsx
+++ b/src/features/Permissions/v1/Components/MemberPermissionCard.tsx
@@ -16,7 +16,7 @@ const MemberPermissionCard = ({ member }: { member: PermissionMember }) => {
         <img
           src={member.image}
           alt={member.name}
-          className="w-14 h-14 rounded-full object-cover"
+          className="w-14 h-14 rounded-full object-cover shrink-0"
         />
         <div className="flex flex-col gap-1">
           <h3

--- a/src/features/Permissions/v1/Components/PermissionChip.tsx
+++ b/src/features/Permissions/v1/Components/PermissionChip.tsx
@@ -1,0 +1,24 @@
+type PermissionChipProps = {
+  label: string;
+  granted: boolean;
+};
+
+const PermissionChip = ({ label, granted }: PermissionChipProps) => {
+  return (
+    <span
+      className="text-xs px-2 py-1 rounded-full font-medium"
+      style={{
+        backgroundColor: granted
+          ? "var(--cd-success-subtle)"
+          : "var(--cd-danger-subtle)",
+        color: granted
+          ? "var(--cd-success)"
+          : "var(--cd-danger)",
+      }}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default PermissionChip;

--- a/src/features/Permissions/v1/Components/PermissionHeader.tsx
+++ b/src/features/Permissions/v1/Components/PermissionHeader.tsx
@@ -1,0 +1,38 @@
+const PermissionHeader = () => {
+  return (
+    <div
+      className="w-full py-[3vh] border-b flex text-xl font-bold justify-between"
+      style={{
+        backgroundColor: "var(--cd-surface)",
+        borderColor: "var(--cd-border)",
+      }}
+    >
+      <div className="w-1/2 h-full flex flex-col justify-between gap-2">
+        <h1
+          className="text-lg sm:text-[2.5vw] lg:text-2xl font-bold ml-5 mt-2"
+          style={{ color: "var(--cd-text)" }}
+        >
+          Permission Management
+        </h1>
+        <span
+          className="text-sm w-fit ml-5 rounded-2xl py-1 px-3"
+          style={{
+            backgroundColor: "var(--cd-surface-2)",
+            color: "var(--cd-text-2)",
+          }}
+        >
+          Manage roles and permissions for all members
+        </span>
+      </div>
+      <div className="w-1/3 h-full flex justify-end items-center gap-3 px-5">
+        <img
+          src="https://randomuser.me/api/portraits/men/1.jpg"
+          className="w-9 h-9 rounded-full object-cover"
+          alt="User avatar"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PermissionHeader;

--- a/src/features/Permissions/v1/Components/PermissionHeader.tsx
+++ b/src/features/Permissions/v1/Components/PermissionHeader.tsx
@@ -26,7 +26,7 @@ const PermissionHeader = () => {
       </div>
       <div className="w-1/3 h-full flex justify-end items-center gap-3 px-5">
         <img
-          src="https://randomuser.me/api/portraits/men/1.jpg"
+          src={`https://ui-avatars.com/api/?name=Admin&background=6366f1&color=fff`}
           className="w-9 h-9 rounded-full object-cover"
           alt="User avatar"
         />

--- a/src/features/Permissions/v1/Components/PermissionSearch.tsx
+++ b/src/features/Permissions/v1/Components/PermissionSearch.tsx
@@ -41,6 +41,7 @@ const PermissionSearch = ({ onSearch }: PermissionSearchProps) => {
           style={{ color: "var(--cd-text)" }}
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
         />
       </div>
 
@@ -48,7 +49,10 @@ const PermissionSearch = ({ onSearch }: PermissionSearchProps) => {
       <div className="w-40">
         <DropDown
           options={ROLE_OPTIONS}
-          onSelect={setSelectedRole}
+          onSelect={(role) => {
+            setSelectedRole(role);
+            onSearch(searchText, role);
+          }}
         />
       </div>
 

--- a/src/features/Permissions/v1/Components/PermissionSearch.tsx
+++ b/src/features/Permissions/v1/Components/PermissionSearch.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { CiSearch } from "react-icons/ci";
+import DropDown from "@/Component/ui/DropDown";
+import Button from "@/Component/ui/Button";
+
+const ROLE_OPTIONS = ["All Roles", "Admin", "Organizer", "Volunteer", "Member", "Visitor"];
+
+type PermissionSearchProps = {
+  onSearch: (text: string, role: string) => void;
+};
+
+const PermissionSearch = ({ onSearch }: PermissionSearchProps) => {
+  const [searchText, setSearchText] = useState("");
+  const [selectedRole, setSelectedRole] = useState(ROLE_OPTIONS[0]);
+
+  const handleSearch = () => {
+    onSearch(searchText, selectedRole);
+  };
+
+  return (
+    <div
+      className="w-[90%] mt-[4vh] flex items-center p-3 rounded-2xl border gap-3"
+      style={{
+        backgroundColor: "var(--cd-surface)",
+        borderColor: "var(--cd-border)",
+      }}
+    >
+      {/* Search input */}
+      <div
+        className="flex-1 h-10 flex items-center gap-2 px-3 border rounded-lg"
+        style={{
+          backgroundColor: "var(--cd-surface-2)",
+          borderColor: "var(--cd-border)",
+        }}
+      >
+        <CiSearch style={{ color: "var(--cd-text-muted)" }} />
+        <input
+          type="text"
+          placeholder="Search member by name..."
+          className="flex-1 h-full bg-transparent outline-none text-sm"
+          style={{ color: "var(--cd-text)" }}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+        />
+      </div>
+
+      {/* Role filter */}
+      <div className="w-40">
+        <DropDown
+          options={ROLE_OPTIONS}
+          onSelect={setSelectedRole}
+        />
+      </div>
+
+      {/* Search button */}
+      <Button
+        text="Search"
+        icon={<CiSearch />}
+        onClick={handleSearch}
+      />
+    </div>
+  );
+};
+
+export default PermissionSearch;

--- a/src/features/Permissions/v1/Pages/PermissionPage.tsx
+++ b/src/features/Permissions/v1/Pages/PermissionPage.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import PermissionHeader from "../Components/PermissionHeader";
+import PermissionSearch from "../Components/PermissionSearch";
+import MemberPermissionCard from "../Components/MemberPermissionCard";
+import { permissionData } from "../mock/permissionData";
+
+const PermissionPage = () => {
+  const [filteredMembers, setFilteredMembers] = useState(permissionData);
+
+  const handleSearch = (text: string, role: string) => {
+    const result = permissionData.filter((member) => {
+      const matchesName = member.name
+        .toLowerCase()
+        .includes(text.toLowerCase());
+      const matchesRole =
+        role === "All Roles" ? true : member.role === role;
+      return matchesName && matchesRole;
+    });
+    setFilteredMembers(result);
+  };
+
+  return (
+    <div
+      className="w-full min-h-screen flex flex-col items-center gap-4 cd-page overflow-y-auto pb-10"
+    >
+      {/* Header */}
+      <PermissionHeader />
+
+      {/* Search & Filter */}
+      <PermissionSearch onSearch={handleSearch} />
+
+      {/* Cards Grid */}
+      {filteredMembers.length > 0 ? (
+        <div className="w-[90%] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 pb-10">
+          {filteredMembers.map((member) => (
+            <MemberPermissionCard key={member.id} member={member} />
+          ))}
+        </div>
+      ) : (
+        /* Empty state */
+        <div
+          className="w-full flex flex-col items-center justify-center gap-3 mt-20"
+        >
+          <p
+            className="text-lg font-semibold"
+            style={{ color: "var(--cd-text)" }}
+          >
+            No members found
+          </p>
+          <p
+            className="text-sm"
+            style={{ color: "var(--cd-text-muted)" }}
+          >
+            Try adjusting your search or filter
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PermissionPage;

--- a/src/features/Permissions/v1/mock/permissionData.ts
+++ b/src/features/Permissions/v1/mock/permissionData.ts
@@ -1,0 +1,107 @@
+export type Permission = {
+  label: string;
+  granted: boolean;
+};
+
+export type PermissionMember = {
+  id: number;
+  name: string;
+  image: string;
+  role: string;
+  email: string;
+  status: string;
+  permissions: Permission[];
+};
+
+export const permissionData: PermissionMember[] = [
+  {
+    id: 1,
+    name: "Arjun Mehta",
+    image: "https://randomuser.me/api/portraits/men/1.jpg",
+    role: "Admin",
+    email: "arjun@commdesk.io",
+    status: "Active",
+    permissions: [
+      { label: "can-create", granted: true },
+      { label: "can-edit", granted: true },
+      { label: "can-delete", granted: true },
+      { label: "can-view", granted: true },
+      { label: "can-publish", granted: true },
+    ],
+  },
+  {
+    id: 2,
+    name: "Priya Sharma",
+    image: "https://randomuser.me/api/portraits/women/2.jpg",
+    role: "Organizer",
+    email: "priya@commdesk.io",
+    status: "Active",
+    permissions: [
+      { label: "can-create", granted: true },
+      { label: "can-edit", granted: true },
+      { label: "can-delete", granted: false },
+      { label: "can-view", granted: true },
+      { label: "can-publish", granted: false },
+    ],
+  },
+  {
+    id: 3,
+    name: "Rahul Verma",
+    image: "https://randomuser.me/api/portraits/men/3.jpg",
+    role: "Volunteer",
+    email: "rahul@commdesk.io",
+    status: "Active",
+    permissions: [
+      { label: "can-create", granted: false },
+      { label: "can-edit", granted: true },
+      { label: "can-delete", granted: false },
+      { label: "can-view", granted: true },
+      { label: "can-publish", granted: false },
+    ],
+  },
+  {
+    id: 4,
+    name: "Sneha Iyer",
+    image: "https://randomuser.me/api/portraits/women/4.jpg",
+    role: "Member",
+    email: "sneha@commdesk.io",
+    status: "Inactive",
+    permissions: [
+      { label: "can-create", granted: false },
+      { label: "can-edit", granted: false },
+      { label: "can-delete", granted: false },
+      { label: "can-view", granted: true },
+      { label: "can-publish", granted: false },
+    ],
+  },
+  {
+    id: 5,
+    name: "Dev Patel",
+    image: "https://randomuser.me/api/portraits/men/5.jpg",
+    role: "Organizer",
+    email: "dev@commdesk.io",
+    status: "Active",
+    permissions: [
+      { label: "can-create", granted: true },
+      { label: "can-edit", granted: true },
+      { label: "can-delete", granted: false },
+      { label: "can-view", granted: true },
+      { label: "can-publish", granted: true },
+    ],
+  },
+  {
+    id: 6,
+    name: "Anaya Singh",
+    image: "https://randomuser.me/api/portraits/women/6.jpg",
+    role: "Visitor",
+    email: "anaya@commdesk.io",
+    status: "Active",
+    permissions: [
+      { label: "can-create", granted: false },
+      { label: "can-edit", granted: false },
+      { label: "can-delete", granted: false },
+      { label: "can-view", granted: true },
+      { label: "can-publish", granted: false },
+    ],
+  },
+];

--- a/src/features/SideBar/v1/Section/SideBar.tsx
+++ b/src/features/SideBar/v1/Section/SideBar.tsx
@@ -1,5 +1,5 @@
 import { RiContactsBookFill } from "react-icons/ri";
-import { MdDashboard, MdEvent, MdGroup, MdSettings, MdWork } from "react-icons/md";
+import { MdDashboard, MdEvent, MdGroup, MdSettings, MdWork, MdSecurity } from "react-icons/md";
 import { useTheme } from "@/theme";
 import { ThemeToggle } from "@/Component/ui/ThemeToggle";
 
@@ -49,6 +49,7 @@ const SideBar = () => {
         <SideBarLink icon={<MdGroup />} text="Teams" link="/org/member" />
         <SideBarLink icon={<MdEvent />} text="Events" link="/org/events" />
         <SideBarLink icon={<RiContactsBookFill />} text="Contact Submissions" link="/org/contact" />
+        <SideBarLink icon={<MdSecurity />} text="Permissions" link="/org/permissions" />
 
         {/* Footer */}
         <div

--- a/src/routes/OrgRoute.tsx
+++ b/src/routes/OrgRoute.tsx
@@ -7,6 +7,7 @@ import ViewEvent from "@/features/Events/v1/Pages/ViewEvent";
 import MemberPage from "@/features/Member/v1/Pages/MemberPage";
 import ProjectsPage from "@/features/Projects/Pages/ProjectsPage";
 import Organisation_Template from "@/features/template/LoginUserTemplate";
+import PermissionPage from "@/features/Permissions/v1/Pages/PermissionPage";
 
 const OrgRoute = () => {
   return (
@@ -32,6 +33,8 @@ const OrgRoute = () => {
 
       {/* Add Member */}
       <Route path="add-member" element={<AddMemberPage />} />
+
+      <Route path="permissions" element={<PermissionPage />} />
     </Route>
 
     </Routes>


### PR DESCRIPTION
Closes #69

## What's changed
- Added Permission Management page at `/org/permissions`
- Card-based layout (no tables) as requested
- Each card shows avatar, name, email, role chip, status badge
- Permission chips — green for granted, red for denied
- Search by member name
- Filter by role (Admin, Organizer, Volunteer, Member, Visitor)
- Empty state when no results found
- Permissions link added to sidebar
- Follows existing CommDesk design system and folder structure
- Mock data used until backend API is available

## Screenshots
<img width="1920" height="892" alt="Screenshot (57)" src="https://github.com/user-attachments/assets/3b314b19-a818-4d84-b388-f0c752b29b1f" />


## Checklist
- [x] Permission page accessible at `/org/permissions`
- [x] Members displayed as cards (no tables)
- [x] Each card shows image, name, role, permission chips
- [x] Search bar filters members by name
- [x] Role filter works correctly
- [x] Empty state handled
- [x] Follows existing CommDesk design system
- [x] No new TypeScript errors introduced