### PR TITLE
fix: add CSP security headers

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
     ],
 
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://api.github.com;"
     }
   },
 


### PR DESCRIPTION
This PR adds Content-Security-Policy (CSP) headers to the Tauri configuration to prevent XSS attacks and securely isolate the application. Fixes #107