### PR TITLE
Fix: Add maximum length validation for communityName and communityBio (issue #129)

### DIFF
--- a/src/features/Auth/v1/hooks/useSignupForm.ts
+++ b/src/features/Auth/v1/hooks/useSignupForm.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 
 export const signupSchema = z
   .object({
-    communityName: z.string().min(2, "Community name must be at least 2 characters"),
-    communityBio: z.string().min(10, "Bio must be at least 10 characters"),
+    communityName: z.string().min(2, "Community name must be at least 2 characters").max(100, "Community name must not exceed 100 characters"),
+    communityBio: z.string().min(10, "Bio must be at least 10 characters").max(500, "Bio must not exceed 500 characters"),
     communityLogo: z.string().optional(),
     communityWebsite: z
       .string()


### PR DESCRIPTION
## Summary

Adds maximum length validation constraints to the `communityName` and `communityBio` fields in the signup form schema. These fields previously had only minimum length requirements, allowing users to submit arbitrarily long strings that could cause UI layout issues, database storage bloat, and field overflow.

## Problem Statement

The signup schema in `src/features/Auth/v1/hooks/useSignupForm.ts` validates input fields with only minimum length constraints:

```typescript
communityName: z.string().min(2, "Community name must be at least 2 characters"),
communityBio: z.string().min(10, "Bio must be at least 10 characters"),
```

Without maximum length constraints:
1. Users can submit community names or bios containing thousands of characters
2. Oversized community names cause layout corruption in UI elements (headers, sidebars, dropdowns)
3. Oversized bios inflate database storage and exceed column width limits
4. No validation feedback to users when they exceed reasonable limits

## Solution

Added maximum length constraints:
- `communityName`: Limited to 100 characters (suitable for community header displays)
- `communityBio`: Limited to 500 characters (suitable for textarea display and database storage)

These limits are:
- **Reasonable:** Accommodates typical community descriptions while preventing abuse
- **Enforced at validation:** Zod validates before submission, providing immediate user feedback
- **Clearly communicated:** Error messages inform users of exceeded limits

## Changes Made

**File:** `src/features/Auth/v1/hooks/useSignupForm.ts`

**Before:**
```typescript
communityName: z.string().min(2, "Community name must be at least 2 characters"),
communityBio: z.string().min(10, "Bio must be at least 10 characters"),
```

**After:**
```typescript
communityName: z.string().min(2, "Community name must be at least 2 characters").max(100, "Community name must not exceed 100 characters"),
communityBio: z.string().min(10, "Bio must be at least 10 characters").max(500, "Bio must not exceed 500 characters"),
```

## Testing

The changes can be tested by:

1. **Frontend validation:**
   - Navigate to community signup form (step 1)
   - Enter community name exceeding 100 characters
   - Verify validation error message appears
   - Verify form submission is blocked

2. **Bio validation:**
   - On the same form
   - Enter bio text exceeding 500 characters
   - Verify validation error message appears
   - Verify form submission is blocked

3. **Valid submissions:**
   - Enter community name with 2-100 characters
   - Enter bio with 10-500 characters
   - Verify form validation passes and submission proceeds

## Impact

- **User Experience:** Users receive clear feedback when field limits are exceeded
- **Data Integrity:** Prevents oversized values from corrupting database or UI
- **Security:** Reduces attack surface for DoS via input bloat
- **Compliance:** Aligns with UI/UX best practices for form validation

## Related Issues

Fixes #129