### PR TITLE
fix: size and center the main window relative to the actual monitor

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,42 @@
+use tauri::{LogicalSize, Manager, WebviewWindow};
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
+}
+
+// tauri.conf.json's width/height (1200x800) are only used as a fallback for
+// the brief moment before this runs, and as the size on platforms where
+// monitor info is unavailable at startup. The window starts hidden
+// (`visible: false` in tauri.conf.json) so the resize below never causes a
+// visible flash.
+const TARGET_WORK_AREA_RATIO: f64 = 0.75;
+const MIN_LOGICAL_WIDTH: f64 = 1000.0;
+const MIN_LOGICAL_HEIGHT: f64 = 700.0;
+const MAX_LOGICAL_WIDTH: f64 = 1600.0;
+const MAX_LOGICAL_HEIGHT: f64 = 1000.0;
+
+/// Resizes and centers the window relative to the current monitor's
+/// available work area (screen size minus taskbars/docks), scaled for its
+/// DPI, and clamped to a sane min/max so it is never unusably small on a
+/// dense display nor absurdly large on an ultrawide one.
+fn size_window_for_monitor(window: &WebviewWindow) {
+    let monitor = match window.primary_monitor() {
+        Ok(Some(monitor)) => monitor,
+        _ => return,
+    };
+
+    let scale_factor = monitor.scale_factor();
+    let work_area_logical: LogicalSize<f64> = monitor.work_area().size.to_logical(scale_factor);
+
+    let target_width =
+        (work_area_logical.width * TARGET_WORK_AREA_RATIO).clamp(MIN_LOGICAL_WIDTH, MAX_LOGICAL_WIDTH);
+    let target_height = (work_area_logical.height * TARGET_WORK_AREA_RATIO)
+        .clamp(MIN_LOGICAL_HEIGHT, MAX_LOGICAL_HEIGHT);
+
+    let _ = window.set_size(LogicalSize::new(target_width, target_height));
+    let _ = window.center();
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -11,6 +46,15 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![greet])
+        .setup(|app| {
+            if let Some(window) = app.get_webview_window("main") {
+                size_window_for_monitor(&window);
+                // Always show, even if monitor detection above failed —
+                // the window must never stay hidden.
+                let _ = window.show();
+            }
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,8 +18,12 @@
         "title": "CommDesk",
         "width": 1200,
         "height": 800,
+        "minWidth": 1000,
+        "minHeight": 700,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "center": true,
+        "visible": false
       }
     ],
 


### PR DESCRIPTION
## Summary

Closes #141.

`tauri.conf.json` hardcoded `width`/`height` (1200x800) with no logic anywhere to adapt that to the screen the app actually launches on. The same fixed size showed up whether the user had a small laptop panel or a large external display, and the window had no explicit centering, so its start position depended on OS defaults.

## What Was Changed

- `src-tauri/src/lib.rs`: adds a `setup` hook that reads the primary monitor's work area (screen size minus taskbar/dock) and scale factor, computes a target size at 75% of that work area in logical pixels, clamps it to a 1000x700 to 1600x1000 range so it's never unusably small or absurdly large, sets that size, and centers the window. Falls back silently to the static `tauri.conf.json` size if monitor detection is unavailable (can happen on some Linux setups at startup), and always calls `window.show()` regardless of whether monitor detection succeeded, so the window can never end up permanently hidden.
- `src-tauri/tauri.conf.json`: added `minWidth`/`minHeight` (1000x700) so a user can't resize below a usable size regardless of the computed initial size, added `center: true` as a declarative fallback, and set `visible: false` so the window is created hidden and only shown once the setup hook has finished computing and applying its real size. This avoids a visible flash/jump from the old 1200x800 default to the computed size.

## Test Plan

- [x] `cargo check` and `cargo clippy` — both clean, zero warnings
- [x] Ran the actual app with `pnpm tauri dev`, not just a compile check
- [x] Queried the live window's real bounds via Quartz (`CGWindowListCopyWindowInfo`) rather than relying on a screenshot: on this machine's display (1470x956 logical resolution), the window came up at `1103x700`, i.e. correctly computed as roughly 75% of the available work area width, with the height clamped to the 700 minimum, and positioned near the center of the screen rather than a default corner
- [x] No visible resize flash is possible given the hide-until-sized structure (window is created with `visible: false` and only shown after `set_size`/`center` run synchronously in `setup`)

## Related Issues / PRs

Closes #141.